### PR TITLE
support flexible meshes

### DIFF
--- a/flowmap/formats/ugrid.py
+++ b/flowmap/formats/ugrid.py
@@ -144,7 +144,7 @@ class UGrid(NetCDF):
         return polys
 
     def to_polydata(self):
-        """convert grid to polydata"""
+        """convert grid to a vtk polydata object"""
         grid = self.ugrid
 
         faces = grid['faces']
@@ -167,6 +167,7 @@ class UGrid(NetCDF):
         return polydata
 
     def update_polydata(self, polydata, t):
+        """set velocities to the polydata"""
         variables = self.velocities(t)
         ucx = variables['ucx']
         ucy = variables['ucy']
@@ -177,6 +178,7 @@ class UGrid(NetCDF):
 
 
     def waterlevel(self, t):
+        """lookup the waterlevel, depth and volume on timestep t"""
         # TODO: inspect mesh variable
         with netCDF4.Dataset(self.path) as ds:
             s1 = ds.variables['mesh2d_s1'][t]
@@ -189,6 +191,7 @@ class UGrid(NetCDF):
         )
 
     def velocities(self, t):
+        """lookup the velocities on the cell centers on timestep t"""
         # TODO: inspect mesh variables
         with netCDF4.Dataset(self.path) as ds:
             # cumulative velocities
@@ -200,6 +203,7 @@ class UGrid(NetCDF):
         )
 
     def streamlines(self, t):
+        """compute streamlines for timestep t"""
         polydata = self.to_polydata()
         self.update_polydata(polydata, t)
         seed = particles.make_particles(polydata, n=self.options.get('n_particles', 1000))
@@ -222,6 +226,7 @@ class UGrid(NetCDF):
         particles.export_lines(lines, str(new_name))
 
     def build_is_grid(self, dem):
+        """create a map in the same shape as dem denoting if a pixel is in or outside the grid"""
         is_grid = np.zeros_like(dem['band'], dtype='bool')
         polydata = self.to_polydata()
         hull = topology.concave_hull(polydata)
@@ -243,6 +248,7 @@ class UGrid(NetCDF):
         return is_grid
 
     def build_id_grid(self, dem):
+        """create a map in the same shape as dem, with face number for each pixel"""
         id_grid_name = self.generate_name(
             self.path,
             suffix='.tiff',

--- a/flowmap/formats/ugrid.py
+++ b/flowmap/formats/ugrid.py
@@ -285,7 +285,8 @@ class UGrid(NetCDF):
                 tables = subgrid.import_tables(str(table_path))
             else:
                 logger.info('creating subgrid tables')
-                tables = subgrid.build_tables(grid, dem)
+                id_grid = subgrid.build_id_grid(dem)
+                tables = subgrid.build_tables(grid, dem, id_grid)
             logger.info('computing subgrid band')
             if format == '.geojson':
                 if method == 'waterdepth':

--- a/flowmap/formats/ugrid.py
+++ b/flowmap/formats/ugrid.py
@@ -79,11 +79,18 @@ class UGrid(NetCDF):
         ugrid = pyugrid.UGrid.from_ncfile(self.path, 'mesh2d')
 
         faces = np.ma.asanyarray(ugrid.faces)
+
+        # TODO: check why we get circumcenters?
+        # Don't use these, these are circumcenters
         face_centers = ugrid.face_coordinates
+
         nodes = ugrid.nodes
         # should be a ragged array
         face_coordinates = np.ma.asanyarray(nodes[faces])
         face_coordinates[faces.mask] = np.ma.masked
+
+        # recompute face centers
+        face_centroids = face_coordinates.mean(axis=1)
 
         x = nodes[:, 0]
         y = nodes[:, 1]
@@ -92,6 +99,7 @@ class UGrid(NetCDF):
         return dict(
             face_coordinates=face_coordinates,
             face_centers=face_centers,
+            face_centroids=face_centroids,
             faces=faces,
             points=points
         )

--- a/flowmap/subgrid.py
+++ b/flowmap/subgrid.py
@@ -76,7 +76,6 @@ def build_interpolate(grid, values):
     L = scipy.interpolate.LinearNDInterpolator(face_centroids, values)
     return L
 
-
 def build_tables(grid, dem, id_grid):
     """compute volume tables per cell"""
 

--- a/flowmap/subgrid.py
+++ b/flowmap/subgrid.py
@@ -72,8 +72,8 @@ def subgrid_compute(row, dem, method="waterlevel"):
 def build_interpolate(grid, values):
     """create an interpolation function"""
     # assert a pyugrid
-    face_centers = grid['face_centers']
-    L = scipy.interpolate.LinearNDInterpolator(face_centers, values)
+    face_centroids = grid['face_centroids']
+    L = scipy.interpolate.LinearNDInterpolator(face_centroids, values)
     return L
 
 
@@ -152,7 +152,7 @@ def compute_features(grid, dem, tables, data, method='waterdepth'):
     """compute subgrid waterdepth band"""
 
     # register pandas progress
-    tqdm.tqdm(desc="panda is out for lunch!").pandas()
+    tqdm.tqdm(desc="computing features").pandas()
 
     # list of face indices
     face_ids = np.arange(tables['volume_table'].shape[0])
@@ -163,7 +163,7 @@ def compute_features(grid, dem, tables, data, method='waterdepth'):
 
     results = []
     # fill the in memory band
-    for face_id in tqdm.tqdm(face_ids):
+    for face_id in tqdm.tqdm(face_ids, desc='subgrid compute'):
         row = {}
         for key, var in tables.items():
             row[key] = var[face_id]
@@ -173,13 +173,13 @@ def compute_features(grid, dem, tables, data, method='waterdepth'):
     tables['subgrid_' + method] = results
 
     features = []
-    centers = grid['face_centers']
-    for face_id in tqdm.tqdm(face_ids):
+    centroids = grid['face_centroids']
+    for face_id in tqdm.tqdm(face_ids, desc='exporting features'):
         """convert row 2 features"""
-        center = centers[face_id]
+        centroid = centroids[face_id]
         feature = geojson.Feature(
             geometry=geojson.Point(
-                coordinates=tuple(center)
+                coordinates=tuple(centroid)
             ),
             id=face_id,
             properties={


### PR DESCRIPTION
Integrate flexible mesh (triangles, mixed with quad support), also supports higher degree polygons, but these are not tested yet. 

Implemented in a pixle mask, such as this one for a triangle (the triangle is not masked):
```
[[1, 1, 1, 1, 1, 1, 1, 1],
[1, 1, 1, 0, 0, 1, 1, 1],
[1, 1, 1, 0, 0, 0, 1, 1],
[1, 1, 0, 0, 0, 0, 0, 1],
[1, 1, 0, 0, 0, 0, 0, 1],
[1, 0, 0, 0, 0, 1, 1, 1],
[1, 0, 0, 1, 1, 1, 1, 1],
[0, 1, 1, 1, 1, 1, 1, 1]]
```